### PR TITLE
Fixed Widget Apps not working

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Magic Kard Market Python SDK
 .. image:: https://travis-ci.org/evonove/mkm-sdk.svg
     :target: https://travis-ci.org/evonove/mkm-sdk
 
-A simple SDK for dedicated apps working with Magic Kard Market.
+A simple SDK for dedicated and widget apps working with Magic Kard Market.
 
 Requirements
 ============
@@ -39,6 +39,8 @@ authorization to make requests. You can find them in your Magic Kard Market acco
 * ``MKM_ACCESS_TOKEN_SECRET``
 
 
+`MKM_ACCESS_TOKEN` and `MKM_ACCESS_TOKEN_SECRET` need to be set to empty string if you want to use a widget app.
+
 Usage
 =====
 
@@ -55,6 +57,8 @@ A request works like this::
 This will return a `Response <http://docs.python-requests.org/en/latest/api/?highlight=response#requests.Response/>`_
 object that contains the response from the server.
 
+Note that only `market_place` requests work when using a widget app.
+
 To get a json you can call response.json().
 
 Tests
@@ -67,7 +71,9 @@ Integration tests will be skipped if the four environment variables are not set.
 * ``MKM_ACCESS_TOKEN``
 * ``MKM_ACCESS_TOKEN_SECRET``
 
-There are also other two variable to be set if you don't want to skip your account integration tests.
+There are also other two variable to be set if you don't want to skip your dedicated app's account integration tests.
 
 * ``MKM_ACCOUNT_LAST_NAME``
 * ``MKM_ACCOUNT_FIRST_NAME``
+
+Note that some tests will be skipped depending if `MKM_ACCESS_TOKEN` and `MKM_ACCESS_TOKEN_SECRET` are empty strings or not.

--- a/mkmsdk/MKMClient.py
+++ b/mkmsdk/MKMClient.py
@@ -22,7 +22,10 @@ class MKMClient(Client):
                 oauthParamExist = True
                 break
 
-        # We append the empty string oauth_token if it's not already there
+        # We append the empty string oauth_token if it's not already there since MKM expects
+        # the OAuth1 Header to have the parameter in any case, this has to be done otherwise
+        # the response will always be 401 Unauthorized
+        # Documentation: https://www.mkmapi.eu/ws/documentation/API:Auth_OAuthHeader
         if not oauthParamExist:
             parameters.append(('oauth_token', ''))
 

--- a/mkmsdk/MKMClient.py
+++ b/mkmsdk/MKMClient.py
@@ -2,16 +2,28 @@ from oauthlib.oauth1 import Client
 
 
 class MKMClient(Client):
+    """
+    A personalized OAuth1 Client used for Widget Applications
+    """
+
     def get_oauth_params(self, request):
-        params = super(MKMClient, self).get_oauth_params(request)
+        """
+        A modified version of the original method get_oauth_params,
+        this version appends the `oauth_token` parameter as an empty
+        string to the parameters list if not found in it
+        """
+
+        parameters = super(MKMClient, self).get_oauth_params(request)
 
         oauthParamExist = False
-        for tuple in params:
-            if 'oauth_token' in tuple:
+        # Loop through the parameters to check if oauth_token is found
+        for param in parameters:
+            if 'oauth_token' in param:
                 oauthParamExist = True
                 break
 
+        # We append the empty string oauth_token if it's not already there
         if not oauthParamExist:
-            params.append(('oauth_token', ''))
+            parameters.append(('oauth_token', ''))
 
-        return params
+        return parameters

--- a/mkmsdk/MKMClient.py
+++ b/mkmsdk/MKMClient.py
@@ -1,0 +1,17 @@
+from oauthlib.oauth1 import Client
+
+
+class MKMClient(Client):
+    def get_oauth_params(self, request):
+        params = super(MKMClient, self).get_oauth_params(request)
+
+        oauthParamExist = False
+        for tuple in params:
+            if 'oauth_token' in tuple:
+                oauthParamExist = True
+                break
+
+        if not oauthParamExist:
+            params.append(('oauth_token', ''))
+
+        return params

--- a/mkmsdk/MKMOAuth1.py
+++ b/mkmsdk/MKMOAuth1.py
@@ -23,7 +23,9 @@ class MKMOAuth1(OAuth1):
     @staticmethod
     def decode_signature(given_header):
         """
-        Decodes the signature given an header
+        Decodes the signature given an header. This is done because MKM
+        expects an authorization header with different parameters encoding
+        specified in section 3.6 of OAuth 1 specification (RFC5849).
 
         Parameters:
             `given_header`: Authorization header

--- a/mkmsdk/api.py
+++ b/mkmsdk/api.py
@@ -72,11 +72,9 @@ class Api:
         access_token = access_token if access_token != None else get_mkm_access_token()
         access_token_secret = access_token_secret if access_token_secret != None else get_mkm_access_token_secret()
 
-        """
-        If access_token and access_token_secret are empty strings a personalized OAuth1 Client is used.
-        This is done because that would mean the user is using a Widget Application and having empty strings
-        as tokens causes issues with the default Client
-        """
+        # If access_token and access_token_secret are empty strings a personalized OAuth1 Client is used.
+        # This is done because that would mean the user is using a Widget Application and having empty strings
+        # as tokens causes issues with the default Client
         if not access_token and not access_token_secret:
             client = MKMClient
         else:

--- a/mkmsdk/api.py
+++ b/mkmsdk/api.py
@@ -1,6 +1,7 @@
 from requests import request
+from oauthlib.oauth1.rfc5849 import Client
 
-from mkmsdk.MKMClient import MKMClient
+from .MKMClient import MKMClient
 from . import exceptions
 from . import get_mkm_app_token, get_mkm_app_secret, get_mkm_access_token, get_mkm_access_token_secret
 from .MKMOAuth1 import MKMOAuth1
@@ -70,10 +71,16 @@ class Api:
         app_secret = app_secret if app_secret != None else get_mkm_app_secret()
         access_token = access_token if access_token != None else get_mkm_access_token()
         access_token_secret = access_token_secret if access_token_secret != None else get_mkm_access_token_secret()
-        client = None
 
+        """
+        If access_token and access_token_secret are empty strings a personalized OAuth1 Client is used.
+        This is done because that would mean the user is using a Widget Application and having empty strings
+        as tokens causes issues with the default Client
+        """
         if not access_token and not access_token_secret:
             client = MKMClient
+        else:
+            client = Client
 
         return MKMOAuth1(app_token,
                          client_secret=app_secret,

--- a/tests/tests_integration/__init__.py
+++ b/tests/tests_integration/__init__.py
@@ -22,6 +22,11 @@ def skip_account_integration():
     except KeyError:
         return True
 
-@unittest.skipIf(skip_integration(), "Missing env vars, skipping integration test")
+def skip_dedicated_app_integration():
+    if (mkmsdk.get_mkm_access_token() == '' or mkmsdk.get_mkm_access_token_secret() == ''):
+        return True
+    return False
+
+@unittest.skipIf(skip_integration(), 'Missing env vars, skipping integration test')
 class IntegrationTest(unittest.TestCase):
     pass

--- a/tests/tests_integration/__init__.py
+++ b/tests/tests_integration/__init__.py
@@ -23,9 +23,12 @@ def skip_account_integration():
         return True
 
 def skip_dedicated_app_integration():
-    if (mkmsdk.get_mkm_access_token() == '' or mkmsdk.get_mkm_access_token_secret() == ''):
+    try:
+        os.environ['MKM_ACCESS_TOKEN'] == ''
+        os.environ['MKM_ACCESS_TOKEN_SECRET'] == ''
+        return False
+    except KeyError:
         return True
-    return False
 
 @unittest.skipIf(skip_integration(), 'Missing env vars, skipping integration test')
 class IntegrationTest(unittest.TestCase):

--- a/tests/tests_integration/test_api.py
+++ b/tests/tests_integration/test_api.py
@@ -7,5 +7,5 @@ class ApiTest(IntegrationTest):
         self.new_api = Api(sandbox_mode=True)
 
     def test_good_request(self):
-        response = self.new_api.request('/account', 'get')
+        response = self.new_api.request('/games', 'get')
         self.assertEqual(response.status_code, 200)

--- a/tests/tests_integration/test_mkm.py
+++ b/tests/tests_integration/test_mkm.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from mkmsdk.mkm import mkm_sandbox
 from . import IntegrationTest
 
@@ -12,7 +13,7 @@ class MkmTest(IntegrationTest):
             'game': [
                 {'idGame': 1, 'name': 'Magic the Gathering'},
                 {'idGame': 3, 'name': 'Yugioh'},
-                {'idGame': 6, 'name': 'Pokémon'},
+                {'idGame': 6, 'name': u'Pokémon'},
                 {'idGame': 2, 'name': 'World of Warcraft TCG'},
                 {'idGame': 5, 'name': 'The Spoils'}
             ]

--- a/tests/tests_integration/test_mkm.py
+++ b/tests/tests_integration/test_mkm.py
@@ -12,7 +12,7 @@ class MkmTest(IntegrationTest):
             'game': [
                 {'idGame': 1, 'name': 'Magic the Gathering'},
                 {'idGame': 3, 'name': 'Yugioh'},
-                {'idGame': 6, 'name': 'Pokemon'},
+                {'idGame': 6, 'name': 'Pokémon'},
                 {'idGame': 2, 'name': 'World of Warcraft TCG'},
                 {'idGame': 5, 'name': 'The Spoils'}
             ]
@@ -23,5 +23,5 @@ class MkmTest(IntegrationTest):
         self.assertEqual(first_game_received, expected_response['game'], 'Game received is not correct')
 
     def test_sandbox_url(self):
-        response = mkm_sandbox.account_management.account()
-        self.assertEqual(response.request.url, 'https://sandbox.mkmapi.eu/ws/v1.1/output.json/account')
+        response = mkm_sandbox.market_place.games()
+        self.assertEqual(response.request.url, 'https://sandbox.mkmapi.eu/ws/v1.1/output.json/games')

--- a/tests/tests_unit/test_api.py
+++ b/tests/tests_unit/test_api.py
@@ -1,11 +1,9 @@
 import unittest
 
 from oauthlib.oauth1 import Client
-
-from mkmsdk.MKMClient import MKMClient
-from mkmsdk.MKMOAuth1 import MKMOAuth1
 from ..compat import mock
 
+from mkmsdk.MKMClient import MKMClient
 from mkmsdk.api import Api
 from mkmsdk import exceptions
 from mkmsdk import get_mkm_app_secret

--- a/tests/tests_unit/test_api.py
+++ b/tests/tests_unit/test_api.py
@@ -1,4 +1,9 @@
 import unittest
+
+from oauthlib.oauth1 import Client
+
+from mkmsdk.MKMClient import MKMClient
+from mkmsdk.MKMOAuth1 import MKMOAuth1
 from ..compat import mock
 
 from mkmsdk.api import Api
@@ -12,6 +17,32 @@ class ApiTest(unittest.TestCase):
         self.api = Api()
         self.response = mock.Mock()
         self.response.content = {}
+
+    def test_create_auth(self):
+        auth = self.api.create_auth('https://www.mkmapi.eu/ws/v1.1/output.json',
+                                    app_token='app_token',
+                                    app_secret='app_secret',
+                                    access_token='access_token',
+                                    access_token_secret='access_token_secret')
+
+        self.assertIsInstance(auth.client, Client)
+        self.assertEqual(auth.client.client_key, 'app_token')
+        self.assertEqual(auth.client.client_secret, 'app_secret')
+        self.assertEqual(auth.client.resource_owner_key, 'access_token')
+        self.assertEqual(auth.client.resource_owner_secret, 'access_token_secret')
+
+    def test_create_auth_with_empty_string_token(self):
+        auth = self.api.create_auth('https://www.mkmapi.eu/ws/v1.1/output.json',
+                                    app_token='app_token',
+                                    app_secret='app_secret',
+                                    access_token='',
+                                    access_token_secret='')
+
+        self.assertIsInstance(auth.client, MKMClient)
+        self.assertEqual(auth.client.client_key, 'app_token')
+        self.assertEqual(auth.client.client_secret, 'app_secret')
+        self.assertEqual(auth.client.resource_owner_key, '')
+        self.assertEqual(auth.client.resource_owner_secret, '')
 
     def test_missing_env_var_raise_exception_correctly(self):
         with mock.patch('mkmsdk.os') as os_mocked:

--- a/tests/tests_unit/test_client.py
+++ b/tests/tests_unit/test_client.py
@@ -1,0 +1,35 @@
+import unittest
+
+from oauthlib.common import Request
+
+from mkmsdk.MKMClient import MKMClient
+
+
+class ClientTest(unittest.TestCase):
+
+    def test_get_oauth_params(self):
+        """
+        Tests if oauth_token is added to the list of params when an empty string
+        """
+        client = MKMClient(client_key='app_token',
+                           client_secret='app_secret',
+                           resource_owner_key='',
+                           resource_owner_secret='',
+                           realm='https://sandbox.mkmapi.eu',
+                           nonce='0987654321',
+                           timestamp='1234567890')
+
+        params = client.get_oauth_params(Request(uri='https://sandbox.mkmapi.eu'))
+
+        self.assertEqual(params[0][0], 'oauth_nonce')
+        self.assertEqual(params[0][1], '0987654321')
+        self.assertEqual(params[1][0], 'oauth_timestamp')
+        self.assertEqual(params[1][1], '1234567890')
+        self.assertEqual(params[2][0], 'oauth_version')
+        self.assertEqual(params[2][1], '1.0')
+        self.assertEqual(params[3][0], 'oauth_signature_method')
+        self.assertEqual(params[3][1], 'HMAC-SHA1')
+        self.assertEqual(params[4][0], 'oauth_consumer_key')
+        self.assertEqual(params[4][1], 'app_token')
+        self.assertEqual(params[5][0], 'oauth_token')
+        self.assertEqual(params[5][1], '')

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@ envlist =
 
 [testenv]
 pip_pre = False
-downloadcache = {toxworkdir}/cache/
 commands = coverage run -a runtest.py
+passenv = MKM_*
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/mkmsdk
 deps =


### PR DESCRIPTION
Magic Kard Market Widget Apps weren't working, empty string parameters weren't being added to OAuth Header. 
This is solved by creating a custom Client class used when the SDK detects the user is using a Widget App.

This PR fixes #2