### PR TITLE
Updated Python versions supported

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ language: python
 python: "3.5"
 
 env:
-  - TOX_ENV=py27
-  - TOX_ENV=py33
   - TOX_ENV=py34
   - TOX_ENV=py35
+  - TOX_ENV=py36
+  - TOX_ENV=py37
   - TOX_ENV=flake8
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/mkmsdk/MKMOAuth1.py
+++ b/mkmsdk/MKMOAuth1.py
@@ -1,6 +1,6 @@
 from requests_oauthlib import OAuth1
 from requests.utils import to_native_string
-from six.moves.urllib.parse import unquote
+from urllib.parse import unquote
 
 
 class MKMOAuth1(OAuth1):

--- a/mkmsdk/mkm.py
+++ b/mkmsdk/mkm.py
@@ -47,5 +47,6 @@ class Mkm:
         resolver = resolvers.SimpleResolver(self.sandbox_mode)
         return resolver.resolve(api_map=self.api_map, **kwargs)
 
+
 mkm = Mkm(api_map=default_api_map)
 mkm_sandbox = Mkm(api_map=default_api_map, sandbox_mode=True)

--- a/mkmsdk/resolvers.py
+++ b/mkmsdk/resolvers.py
@@ -1,4 +1,4 @@
-from six.moves import urllib_parse
+from urllib.parse import quote
 
 from .api import Api
 from . import exceptions
@@ -39,7 +39,7 @@ class SimpleResolver:
 
         # We percent encode the url so that if any string has spaces,
         # commas or any other special character the url will be correctly formed anyway
-        self.url = urllib_parse.quote(url)
+        self.url = quote(url)
         self.method = method
 
     def resolve(self, api_map=None, data=None, **kwargs):

--- a/mkmsdk/serializer.py
+++ b/mkmsdk/serializer.py
@@ -1,5 +1,5 @@
 from xml.sax.saxutils import XMLGenerator
-from six import StringIO
+from io import StringIO
 
 from .exceptions import SerializationException
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,3 +1,2 @@
 requests
 requests_oauthlib
-six

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,5 +10,4 @@ idna==2.7                 # via requests
 oauthlib==2.1.0           # via requests-oauthlib
 requests-oauthlib==1.0.0
 requests==2.20.1
-six==1.11.0
 urllib3==1.24.1           # via requests

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -36,7 +36,7 @@ readme-renderer==24.0     # via twine
 requests-oauthlib==1.0.0
 requests-toolbelt==0.8.0  # via twine
 requests==2.20.1
-six==1.11.0
+six==1.11.0               # via bleach, livereload, more-itertools, pytest, readme-renderer
 tornado==5.1.1            # via livereload, mkdocs
 tqdm==4.28.1              # via twine
 twine==1.12.1

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     license='MIT',
     description='MagicKardMarket sdk',
     long_description=LONG_DESCRIPTION,
-    install_requires=['requests', 'requests_oauthlib', 'six'],
+    install_requires=['requests', 'requests_oauthlib'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -46,10 +46,10 @@ setup(
         'Intended Audience :: Developers',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     keywords="mkm magickardmarket magiccardmarket sdk",

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ def get_version(package):
     init_py = open(os.path.join(package, '__init__.py')).read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
+
 version = get_version('mkmsdk')
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
     flake8,
-    py27,
-    py33,
     py34,
     py35,
+    py36,
+    py37,
     docs
 
 [testenv]
@@ -14,10 +14,10 @@ passenv = MKM_*
 deps =
     -r{toxinidir}/requirements/dev.txt
 basepython =
-    py27: python2.7
-    py33: python3.3
     py34: python3.4
     py35: python3.5
+    py36: python3.6
+    py37: python3.7
 
 [testenv:docs]
 commands=mkdocs build


### PR DESCRIPTION
Removed support for Python 2.7 and 3.3 and added support for 3.6 and 3.7.
`six` dependency has been removed too.

Solves #33 