### PR TITLE
Fixed typo in get_wants_list

### DIFF
--- a/mkmsdk/api_map.py
+++ b/mkmsdk/api_map.py
@@ -514,10 +514,10 @@ _API_MAP = {
                 },
             },
             "wants_list": {
-                "get_wants_list": {
+                "get_wants_lists": {
                     "url": "/wantslist",
                     "method": "get",
-                    "description": "Returns wants list of the authenticated user",
+                    "description": "Returns wants lists of the authenticated user",
                 },
                 "create_wants_list": {
                     "url": "/wantslist",


### PR DESCRIPTION
There was a typo in the api_map, with two keys of the map being the same ("get_wants_list"). Because of this, it was not possible to use the first endpoint "/wantslist". 