### PR TITLE
fix bug in API_MAP/2.0/wants_list breaking op.

### DIFF
--- a/mkmsdk/api_map.py
+++ b/mkmsdk/api_map.py
@@ -524,7 +524,7 @@ _API_MAP = {
                     "method": "post",
                     "description": "Creates a new wants list for the authenticated user",
                 },
-                "get_wants_list": {
+                "get_wants_list_items": {
                     "url": "/wantslist/{wants}",
                     "method": "get",
                     "description": "Returns the single specified wants list with its details and items"

--- a/mkmsdk/api_map.py
+++ b/mkmsdk/api_map.py
@@ -514,7 +514,7 @@ _API_MAP = {
                 },
             },
             "wants_list": {
-                "get_wants_list": {
+                "get_all_wants_list": {
                     "url": "/wantslist",
                     "method": "get",
                     "description": "Returns wants list of the authenticated user",
@@ -524,7 +524,7 @@ _API_MAP = {
                     "method": "post",
                     "description": "Creates a new wants list for the authenticated user",
                 },
-                "get_wants_list_items": {
+                "get_wants_list": {
                     "url": "/wantslist/{wants}",
                     "method": "get",
                     "description": "Returns the single specified wants list with its details and items"


### PR DESCRIPTION
API_MAP/2.0/wants_list has a dict with duplicate keys (get_wants_list), so only the latest one is preserved, thus making it unable to query for all the wantlists of the authenticated user.

Proposed fix is to rename the get_wants_list "items" key as shown in the code.