### PR TITLE
Fix the shopping cart articles v2.0 endpoint

### DIFF
--- a/mkmsdk/api_map.py
+++ b/mkmsdk/api_map.py
@@ -488,7 +488,7 @@ _API_MAP = {
                     "description": "Delete articles in the authenticated user's stock",
                 },
                 "get_stock_in_cart": {
-                    "url": "/shoppingcart-articles",
+                    "url": "/stock/shoppingcart-articles",
                     "method": "get",
                     "description": "Returns the articles of the authenticated user's stock that are currently in other user's shopping carts",
                 },


### PR DESCRIPTION
The URL for the shopping cart articles in stock management was off in the API map for v2.0.

As a reference, here's the full URL from the docs: https://api.cardmarket.com/ws/documentation/API_2.0:Stock_InCarts